### PR TITLE
[data-ops-challenge] hyuk jung submission

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -53,7 +53,10 @@ jobs:
           run: |
             export BUILD_DIR=$PWD/build
             mkdir -p $BUILD_DIR/
-
+            
+            # Set execute permission on the transform.bash script
+            chmod +x transform.bash
+            
             nix build --profile ./build/on-push-$(date +'%Y-%m-%d_%H-%M-%S') --no-sandbox
 
             find /nix/var/nix/gcroots | xargs ls -l
@@ -67,4 +70,4 @@ jobs:
             # move store to a place where the cache action can read it
             sudo mv /nix/store nix_store_dir
             sudo mv /nix/var/nix/db/db.sqlite nix_store_db.sqlite
-
+            

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -53,10 +53,7 @@ jobs:
           run: |
             export BUILD_DIR=$PWD/build
             mkdir -p $BUILD_DIR/
-            
-            # Set execute permission on the transform.bash script
-            chmod +x transform.bash
-            
+
             nix build --profile ./build/on-push-$(date +'%Y-%m-%d_%H-%M-%S') --no-sandbox
 
             find /nix/var/nix/gcroots | xargs ls -l
@@ -70,4 +67,4 @@ jobs:
             # move store to a place where the cache action can read it
             sudo mv /nix/store nix_store_dir
             sudo mv /nix/var/nix/db/db.sqlite nix_store_db.sqlite
-            
+

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -49,6 +49,9 @@ jobs:
               sudo systemctl start nix-daemon
             fi
 
+        - name: Fix permission
+          run: chmod +x ./transform.bash
+
         - name: run
           run: |
             export BUILD_DIR=$PWD/build

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,7 @@
         mkdir -p $out
 
         cd $src
+        chmod +x ./transform.bash
         BUILD_DIR=$out ./transform.bash
       '';
 

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,6 @@
         mkdir -p $out
 
         cd $src
-        chmod +x ./transform.bash
         BUILD_DIR=$out ./transform.bash
       '';
 

--- a/transform.bash
+++ b/transform.bash
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
-
 jq -rs '
 	[ "user_id", "name", "email", "phone" ],
 	(
@@ -8,12 +7,11 @@ jq -rs '
 		.user_id as $id |
 		.name as $name | (
 			( .emails[] | [ $id , $name , .   , null ] ),
-			[ "TODO", "add", "phone", "here" ]
+			( .phones[] | [ $id , $name , null, . ] )
 		)
 	)
 	| @csv
 ' tests/input/users/*.json > $BUILD_DIR/users.csv
-
 jq -rs '
 	[ "user_id", "policy_number", "carrier", "policy_type", "effective_date", "expiration_date" ],
 	(
@@ -30,7 +28,5 @@ jq -rs '
 	| @csv
 ' tests/input/policies-by-user/*.json > $BUILD_DIR/policies.csv
 
-echo "TODO xsv join" | tee $BUILD_DIR/user-policies.csv
-
-
-
+# Join with all columns from both files, preserving duplicate user_id columns
+xsv join user_id $BUILD_DIR/policies.csv user_id $BUILD_DIR/users.csv > $BUILD_DIR/user-policies.csv


### PR DESCRIPTION
## Windows Environment Notes

While developing and testing this solution on Windows, I encountered a couple of environment-specific issues that might be relevant for other Windows users:

1. **Line Ending Differences**: The Unix-style line endings (LF) in the shell script caused execution errors in my Windows WSL environment. I encountered errors like `/usr/bin/env: 'bash\r': No such file or directory` because Windows was interpreting the carriage returns as part of the command. Converting the script files to use Windows-compatible line endings resolved this issue.

2. **Diff Command Limitations**: When running `diff tests/output.csv user-policies.csv`, the comparison failed because the reference file used Unix-style line endings while my generated file had Windows-style CRLF line endings. I just had to use the `dos2unix` utility to normalize the line endings which allowed diff to work properly. This conversion was done locally and isn't reflected in the PR itself.

These issues are specific to Windows environments and shouldn't affect Unix/Linux users.

Side Note: Thanks for fixing the GitHub actions script for CI related issues!